### PR TITLE
fix: corrects variable name waveportalContract

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
+++ b/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
@@ -190,7 +190,7 @@ const [currentAccount, setCurrentAccount] = useState("");
       if (window.ethereum) {
         const provider = new ethers.providers.Web3Provider
         const signer = provider.getSigner();
-        const wavePortalContract = new ethers.Contract(contractAddress, waveportal.abi, signer);
+        const waveportalContract = new ethers.Contract(contractAddress, waveportal.abi, signer);
 
         /*
          * Call the getAllWaves method from your Smart Contract


### PR DESCRIPTION
Changes wavePortalContract to waveportalContract to match what's on [line 198](https://github.com/zipeducation/buildspace-projects/pull/12/commits/cf85090a219a20b8427d163947124145558c7585#diff-59c3cca9d8a539d7d6ef24148646149327781c4775399dd21f051aae20593022R198).