### PR TITLE
Fixed typo in waveContract.address and waveContractFactory.deploy()

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
+++ b/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
@@ -116,7 +116,9 @@ Lets make sure it works! Here's my updated `run.js`. In this case, I just want t
 ```javascript
 const main = async () => {
   const waveContractFactory = await hre.ethers.getContractFactory('WavePortal');
-  const waveContract = await waveContractFactory.deploy();
+  const waveContract = await waveContractFactory.deploy({
+    value: hre.ethers.utils.parseEther('0.1'),
+  });
   await waveContract.deployed();
   console.log('Contract addy:', waveContract.address);
 

--- a/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
+++ b/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
@@ -137,7 +137,7 @@ const main = async () => {
   let waveTxn = await waveContract.wave('This is wave #2');
   await waveTxn.wait();
 
-  contractBalance = await hre.ethers.provider.getBalance(waveContract.addresss);
+  contractBalance = await hre.ethers.provider.getBalance(waveContract.address);
   console.log(
     'Contract balance:',
     hre.ethers.utils.formatEther(contractBalance)


### PR DESCRIPTION
Fixed a typo in waveContract.address which causes an error when running scripts/run.js:

![image](https://user-images.githubusercontent.com/8124929/134796153-22f7975a-490b-4f85-aa7d-5b4e81f207f7.png)
