### PR TITLE
fix: typo in exports declaration

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_2_Deploy_To_Real_Testnet.md
@@ -79,7 +79,7 @@ We'll need to change our `hardhat.config.js` file. You can find this in the root
 ```javascript
 require('@nomiclabs/hardhat-waffle');
 
-module.export = {
+module.exports = {
   solidity: '0.8.0',
   networks: {
     rinkeby: {


### PR DESCRIPTION
If you copy over the hardhat config in full (including the exports typo), the config won't be picked up and running `compile` will result in the Solidity compiler not being configured properly.

Caused some confusion in the Discord :)

