### PR TITLE
fix: access `abi` key on contract json

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
@@ -122,7 +122,7 @@ Paste the whole JSON file right there!
 
 Now that you have your file with all your ABI content ready to go, it's time to import it into your `App.js` file. Right under where you imported `App.css` go ahead and import your JSON file like so:
 
-`import waveportal from './utils/WavePortal.json';`
+`import contractABI from './utils/WavePortal.json';`
 
 Now that you have this imported and ready to go, you need actually access the ABI content in your code! If you noticed, the contents of that JSON file you imported as a key called `abi`. Thats exactly what you will be accessing in your code here! Let's take a look at where you are actually using this ABI content:
 

--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
@@ -138,7 +138,7 @@ const wave = async () => {
         /*
         * You are defining contractABI right here. Let's change this!
         */
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
+        const waveportalContract = new ethers.Contract(contractAddress, contractABI.abi, signer);
 
         let count = await waveportalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
@@ -159,13 +159,6 @@ const wave = async () => {
     }
   }
   ```
-
-Now that you have a way to access your ABI file let's swap out the property `contractABI` with `waveportal.abi` to have it look something like this:
-  
-`const waveportalContract = new ethers.Contract(contractAddress, waveportal.abi, signer);`
-
-Wow. Feels good to not see errors right?
-
 
 Once you add that file and click the "Wave" button -- **you'll be officially reading data from your contract on the blockchain through your web client**. 
 

--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
@@ -138,7 +138,7 @@ const wave = async () => {
         /*
         * You are defining contractABI right here. Let's change this!
         */
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI.abi, signer);
+        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
 
         let count = await waveportalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());
@@ -184,7 +184,7 @@ const wave = async () => {
       if (ethereum) {
         const provider = new ethers.providers.Web3Provider(ethereum);
         const signer = provider.getSigner();
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
+        const waveportalContract = new ethers.Contract(contractAddress, contractABI.abi, signer);
 
         let count = await waveportalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());

--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
@@ -138,7 +138,7 @@ const wave = async () => {
         /*
         * You are defining contractABI right here. Let's change this!
         */
-        const waveportalContract = new ethers.Contract(contractAddress, contractABI, signer);
+        const waveportalContract = new ethers.Contract(contractAddress, contractABI.abi, signer);
 
         let count = await waveportalContract.getTotalWaves();
         console.log("Retrieved total wave count...", count.toNumber());


### PR DESCRIPTION
The wave write example is missing an accessor for the `abi` key on the contract json. This was present in the example before, but not in this one.