### PR TITLE
fix: pass ethereum to `Web3Provider`

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
+++ b/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
@@ -187,8 +187,9 @@ const [currentAccount, setCurrentAccount] = useState("");
    */
   const getAllWaves = async () => {
     try {
-      if (window.ethereum) {
-        const provider = new ethers.providers.Web3Provider
+      const { ethereum } = window;
+      if (ethereum) {
+        const provider = new ethers.providers.Web3Provider(ethereum);
         const signer = provider.getSigner();
         const wavePortalContract = new ethers.Contract(contractAddress, waveportal.abi, signer);
 


### PR DESCRIPTION
`getAllWaves` was broken due to us not passing Ethereum to its constructor