### PR TITLE
Update Lesson_1_Storing_Messages_From_Users.md

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
+++ b/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
@@ -188,7 +188,7 @@ const [currentAccount, setCurrentAccount] = useState("");
   const getAllWaves = async () => {
     try {
       if (window.ethereum) {
-        const provider = new ethers.providers.Web3Provider
+        const provider = new ethers.providers.Web3Provider(window.ethereum);
         const signer = provider.getSigner();
         const wavePortalContract = new ethers.Contract(contractAddress, waveportal.abi, signer);
 


### PR DESCRIPTION
In the new "getAllWaves()" method, we're referencing a provider but never passed anything in. In this fix, we just reference `window.ethereum`