### PR TITLE
Update: Added note on direct image links & Fix: Changed course-chat to cowork-chat

### DIFF
--- a/NFT_Collection/Section_2/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
+++ b/NFT_Collection/Section_2/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
@@ -102,6 +102,8 @@ We can copy the `Spongebob Cowboy Pants` JSON metadata above and paste it into [
 
 **Note: I'd love for you to create your own JSON metadata instead of just copying mine. Use your own image, name, and description. Maybe you want your NFT to an image of your fav anime character, fav band, whatever!! Make it custom. Don't worry, we'll be able to change this in the future!**
 
+If you decide to use your own image, make sure the URL goes directly to the actual image, not the website that hosts the image! Direct Imgur links look like this - `https://i.imgur.com/123123.png` NOT `https://imgur.com/gallery/123123`. The easiest way to tell is to check if the URL ends in an image extension like `.png` or `.jpg`. 
+
 Now, lets head to our smart contract and change one line. Instead of:
 
 ```solidity

--- a/Solidity_And_Smart_Contracts/Section_2/Lesson_4_Store_Data_On_Smart_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_2/Lesson_4_Store_Data_On_Smart_Contract.md
@@ -150,14 +150,14 @@ This is pretty much the basis of most smart contracts. Read functions. Write fun
 Pretty soon, we'll be able to call these functions from our react app that we'll be working on :).
 
 **Bonus:**\
-Why do we do a `waveTxn.wait();` though? What are we waiting for? Why didn't we do a `.wait()` after we read the total number of waves? Post your thoughts in the course-chat on Discord. Whoever gets the right answer I will give $20 in Ethereum :).
+Why do we do a `waveTxn.wait();` though? What are we waiting for? Why didn't we do a `.wait()` after we read the total number of waves? Post your thoughts in the cowork-chat on Discord. Whoever gets the right answer I will give $20 in Ethereum :).
 
 🤝 Test other users 
 --------------------
 
 So, we probably want someone other than us to send us a wave right? It'd be pretty boring if only we could send a wave!! We want to make our website **multiplayer**!
 
-Check this out. I added a few lines at the bottom of the function. I'm not going to explain it much (but please ask questions in #course-chat). Basically this is how we can simulate other people hitting our functions :). Keep an eye on the wallet addresses in your terminal once you change the code and run it.
+Check this out. I added a few lines at the bottom of the function. I'm not going to explain it much (but please ask questions in #cowork-chat). Basically this is how we can simulate other people hitting our functions :). Keep an eye on the wallet addresses in your terminal once you change the code and run it.
 
 ```javascript
 const main = async () => {

--- a/Solidity_And_Smart_Contracts/Section_2/Lesson_4_Store_Data_On_Smart_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_2/Lesson_4_Store_Data_On_Smart_Contract.md
@@ -150,14 +150,14 @@ This is pretty much the basis of most smart contracts. Read functions. Write fun
 Pretty soon, we'll be able to call these functions from our react app that we'll be working on :).
 
 **Bonus:**\
-Why do we do a `waveTxn.wait();` though? What are we waiting for? Why didn't we do a `.wait()` after we read the total number of waves? Post your thoughts in the cowork-chat on Discord. Whoever gets the right answer I will give $20 in Ethereum :).
+Why do we do a `waveTxn.wait();` though? What are we waiting for? Why didn't we do a `.wait()` after we read the total number of waves? Post your thoughts in the general-chill-chat channel on Discord. Whoever gets the right answer I will give $20 in Ethereum :).
 
 🤝 Test other users 
 --------------------
 
 So, we probably want someone other than us to send us a wave right? It'd be pretty boring if only we could send a wave!! We want to make our website **multiplayer**!
 
-Check this out. I added a few lines at the bottom of the function. I'm not going to explain it much (but please ask questions in #cowork-chat). Basically this is how we can simulate other people hitting our functions :). Keep an eye on the wallet addresses in your terminal once you change the code and run it.
+Check this out. I added a few lines at the bottom of the function. I'm not going to explain it much (but please ask questions in #general-chill-chat). Basically this is how we can simulate other people hitting our functions :). Keep an eye on the wallet addresses in your terminal once you change the code and run it.
 
 ```javascript
 const main = async () => {

--- a/Solidity_And_Smart_Contracts/Section_2/Lesson_5_Deploy_Locally.md
+++ b/Solidity_And_Smart_Contracts/Section_2/Lesson_5_Deploy_Locally.md
@@ -80,7 +80,7 @@ In your terminal window that's keeping your local Ethereum network alive, you'll
 
 ![](https://i.imgur.com/DmhZRJN.png)
 
-INTERESTING. But...what's gas? What does it mean by block #1? What's the big code next to "Transaction"? I want you try and just Google this stuff. Ask questions in #cowork-chat :).
+INTERESTING. But...what's gas? What does it mean by block #1? What's the big code next to "Transaction"? I want you try and just Google this stuff. Ask questions in #general-chill-chat :).
 
 
 🚨 Before you click "Next Lesson"

--- a/Solidity_And_Smart_Contracts/Section_2/Lesson_5_Deploy_Locally.md
+++ b/Solidity_And_Smart_Contracts/Section_2/Lesson_5_Deploy_Locally.md
@@ -80,7 +80,7 @@ In your terminal window that's keeping your local Ethereum network alive, you'll
 
 ![](https://i.imgur.com/DmhZRJN.png)
 
-INTERESTING. But...what's gas? What does it mean by block #1? What's the big code next to "Transaction"? I want you try and just Google this stuff. Ask questions in #course-chat :).
+INTERESTING. But...what's gas? What does it mean by block #1? What's the big code next to "Transaction"? I want you try and just Google this stuff. Ask questions in #cowork-chat :).
 
 
 🚨 Before you click "Next Lesson"

--- a/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
+++ b/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
@@ -66,7 +66,7 @@ contract WavePortal {
 
         /*
          * I added some fanciness here, Google it and try to figure out what it is!
-         * Let me know what you learn in #course-chat
+         * Let me know what you learn in #cowork-chat
          */
         emit NewWave(msg.sender, block.timestamp, _message);
     }
@@ -157,7 +157,7 @@ So, now that we've updated our contract we need to do a few things:
 
 Why do we need to do all this? Well, it's because smart contracts are **immutable.** They can't change. They're permanent. That means changing a contract requires a full redeploy. This will also **reset** all the variables since it'd be treated as a brand new contract. **That means we'd lose all our wave data if we wanted to update the contract's code.**
 
-**Bonus**: In #course-chat, can anyone tell me some solutions here? Where else could we store our wave data where we could update our contract's code and keep our original data around? There are quite a few solutions here let me know what you find!
+**Bonus**: In #cowork-chat, can anyone tell me some solutions here? Where else could we store our wave data where we could update our contract's code and keep our original data around? There are quite a few solutions here let me know what you find!
 
 So what you'll need to do now is:
 

--- a/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
+++ b/Solidity_And_Smart_Contracts/Section_4/Lesson_1_Storing_Messages_From_Users.md
@@ -66,7 +66,7 @@ contract WavePortal {
 
         /*
          * I added some fanciness here, Google it and try to figure out what it is!
-         * Let me know what you learn in #cowork-chat
+         * Let me know what you learn in #general-chill-chat
          */
         emit NewWave(msg.sender, block.timestamp, _message);
     }
@@ -157,7 +157,7 @@ So, now that we've updated our contract we need to do a few things:
 
 Why do we need to do all this? Well, it's because smart contracts are **immutable.** They can't change. They're permanent. That means changing a contract requires a full redeploy. This will also **reset** all the variables since it'd be treated as a brand new contract. **That means we'd lose all our wave data if we wanted to update the contract's code.**
 
-**Bonus**: In #cowork-chat, can anyone tell me some solutions here? Where else could we store our wave data where we could update our contract's code and keep our original data around? There are quite a few solutions here let me know what you find!
+**Bonus**: In #general-chill-chat, can anyone tell me some solutions here? Where else could we store our wave data where we could update our contract's code and keep our original data around? There are quite a few solutions here let me know what you find!
 
 So what you'll need to do now is:
 


### PR DESCRIPTION
A couple of people used Imgur gallery links instead of direct image links, breaking their NFTs, as they appeared to not have an image.

I've added the following in section 2, lesson 4, right after the note to create their own metadata.

> If you decide to use your own image, make sure the URL goes directly to the actual image, not the website that hosts the image! Direct Imgur links look like this - `https://i.imgur.com/123123.png` NOT `https://imgur.com/gallery/123123`. The easiest way to tell is to check if the URL ends in an image extension like `.png` or `.jpg`.