### PR TITLE
Update wave txn variable name to avoid compiler errors

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
+++ b/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
@@ -133,11 +133,11 @@ const main = async () => {
   /*
    * Let's try two waves now
    */
-  let waveTxn = await waveContract.wave('This is wave #1');
+  const waveTxn = await waveContract.wave('This is wave #1');
   await waveTxn.wait();
 
-  let waveTxn = await waveContract.wave('This is wave #2');
-  await waveTxn.wait();
+  const waveTxn2 = await waveContract.wave('This is wave #2');
+  await waveTxn2.wait();
 
   contractBalance = await hre.ethers.provider.getBalance(waveContract.address);
   console.log(


### PR DESCRIPTION
Another option would be to remove the let if `waveTxn` variable was to be reused.

I chose to just name it `waveTxn2` here.