### PR TITLE
Typo fix - All mention of currency now Ether

### DIFF
--- a/Solidity_And_Smart_Contracts/Section_1/Lesson_1_Welcome.md
+++ b/Solidity_And_Smart_Contracts/Section_1/Lesson_1_Welcome.md
@@ -3,7 +3,7 @@
 
 You've made it — hell yeah! Welcome :). My name is Farza and I’ll be your instructor. This project is for devs that want to get more into crypto tech. All you really need to know going into this: some terminal skills, some javascript, some react.js. You'll pick up the rest along the way.
 
-Few action items for you before moving on:
+A few action items for you before moving on:
 
 1. **Connect your Discord in the course dashboard.** All the good stuff is going to be happening in a secret category in the Discord that you'll only have access to if you connect your Discord.
 2. **Connect your Ethereum wallet in the course dashboard.** If you don't have a wallet that can interact with dApps, you can just install Metamask for free right now. Without a wallet, you can't do the project!
@@ -67,7 +67,7 @@ You'll be building a website that I'll be calling the WavePortal --- it'll be a 
 
 You'll be writing + deploying the smart contract and you'll also be building the website that will let people actually connect their wallets and interact with your smart contract.
 
-We're going to make this a little spicy as well. Basically, when someone waves at you there is a random chance they can win a small amount of Ethereum from your site :).
+We're going to make this a little spicy as well. Basically, when someone waves at you there is a random chance they can win a small amount of Ether from your site :).
 
 You'll be able to customize the website as much as you want. For example:
 - Maybe instead of a 👋 you want people to send you a 💩.

--- a/Solidity_And_Smart_Contracts/Section_2/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
+++ b/Solidity_And_Smart_Contracts/Section_2/Lesson_1_Get_Your_Local_Ethereum_Network_Running.md
@@ -20,7 +20,7 @@ If you have any issues throughout here, just drop a message on Discord in  `#se
 ✨ The magic of Hardhat
 ----------------------
 
-1\. We're going to be using a tool called Hardhat a lot. This will let us easily spin up a local Ethereum network and give us fake test Ethereum and fake test accounts to work with. Remember, it's just like a local server, except the "server" is the blockchain
+1\. We're going to be using a tool called Hardhat a lot. This will let us easily spin up a local Ethereum network and give us fake test Ether and fake test accounts to work with. Remember, it's just like a local server, except the "server" is the blockchain
 
 2\. Quickly compile smart contracts and test them on our local blockchain
 

--- a/Solidity_And_Smart_Contracts/Section_2/Lesson_4_Store_Data_On_Smart_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_2/Lesson_4_Store_Data_On_Smart_Contract.md
@@ -150,7 +150,7 @@ This is pretty much the basis of most smart contracts. Read functions. Write fun
 Pretty soon, we'll be able to call these functions from our react app that we'll be working on :).
 
 **Bonus:**\
-Why do we do a `waveTxn.wait();` though? What are we waiting for? Why didn't we do a `.wait()` after we read the total number of waves? Post your thoughts in the course-chat on Discord. Whoever gets the right answer I will give $20 in Ethereum :).
+Why do we do a `waveTxn.wait();` though? What are we waiting for? Why didn't we do a `.wait()` after we read the total number of waves? Post your thoughts in the course-chat on Discord. Whoever gets the right answer I will give $20 in Ether :).
 
 🤝 Test other users 
 --------------------

--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_2_Deploy_To_Real_Testnet.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_2_Deploy_To_Real_Testnet.md
@@ -54,7 +54,7 @@ There are a few testnets out there and the one we'll be using is called "Rinkeby
 
 In order to deploy to Rinkeby, we need fake ether. Why? Because if you were deploying to the actual Ethereum mainnet, you'd use real money! So, testnets copies how mainnet works, only difference is no real money is involved.
 
-In order get fake ether, we have to ask the network for some. **This fake ether will only work on this specific testnet.** You can grab some fake Ethereum for Rinkeby through a faucet. 
+In order get fake ether, we have to ask the network for some. **This fake ether will only work on this specific testnet.** You can grab some fake Ether for Rinkeby through a faucet. 
 
 For MyCrpyto, you'll need to connect your wallet, make an account, and then click that same link again to request funds. For the official rinkeby faucet, if it lists 0 peers, it is not worth the time to make a tweet/public Facebook post.
 
@@ -69,7 +69,7 @@ For MyCrpyto, you'll need to connect your wallet, make an account, and then clic
 🙃 Having trouble getting Testnet ETH?
 -----------------------------------
 
-If the above link doesn't work, please send me your public wallet address and request 0.01 ETH in #faucet-request and drop a funny gif. Either me, or someone from the course will send you some faker ether as soon as they can. The funnier the gif, the faster you will get sent fake ether LOL.
+If the above link doesn't work, please send me your public wallet address and request 0.01 ETH in #faucet-request and drop a funny gif. Either me, or someone from the course will send you some fake ether as soon as they can. The funnier the gif, the faster you will get sent fake ether LOL.
 
 📈 Deploy to Rinkeby testnet.
 ---------------------------------

--- a/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
+++ b/Solidity_And_Smart_Contracts/Section_3/Lesson_4_Call_Deployed_Contract.md
@@ -213,7 +213,7 @@ When we run this, you'll see that total wave count is increased by 1. You'll als
 
 **NICEEEEEEE :).**
 
-Really good stuff. We now have an actual client that can read and write data to the blockchain. From here, you can do whatever you want. You have the basics down. You can build a decentralized version of Twitter. You can build a way for people to post their favorite memes and allow people to "tip" the people who post the best memes with Ethereum. You can build a decentralized voting system that a country can use to vote in a politician where everything is open and clear. 
+Really good stuff. We now have an actual client that can read and write data to the blockchain. From here, you can do whatever you want. You have the basics down. You can build a decentralized version of Twitter. You can build a way for people to post their favorite memes and allow people to "tip" the people who post the best memes with Ether. You can build a decentralized voting system that a country can use to vote in a politician where everything is open and clear. 
 
 The possibilities are truly endless.
 

--- a/Solidity_And_Smart_Contracts/Section_4/Lesson_2_Fund_Contract_Set_Prize.md
+++ b/Solidity_And_Smart_Contracts/Section_4/Lesson_2_Fund_Contract_Set_Prize.md
@@ -1,11 +1,11 @@
 💸 Send Ethereum to people waving at you
 ----------------------------------------
 
-Now what we want to do is send some Ethereum to people waving at us! For example, maybe you want to make it where there's a 1% chance someone can win $5 from waving at you. Or, maybe you want to make it where everyone who waves at you gets $0.01 in Etheruem for waving at you lol.
+Now what we want to do is send some Ether to people waving at us! For example, maybe you want to make it where there's a 1% chance someone can win $5 from waving at you. Or, maybe you want to make it where everyone who waves at you gets $0.01 in Ether for waving at you lol.
 
-You can even make it where you can manually send Ethereum to people whose messages you loved the most. Maybe they sent you an awesome song!!
+You can even make it where you can manually send Ether to people whose messages you loved the most. Maybe they sent you an awesome song!!
 
-**Easily sending Ethereum to users is a core part of smart contracts and one of the coolest parts about them**, so, let's do it!
+**Easily sending Ether to users is a core part of smart contracts and one of the coolest parts about them**, so, let's do it!
 
 To start we're just going to give everyone who waves at us `0.0001 ether`. Which is $0.31 :). And this is all happening on testnet, so, it's fake $!
 
@@ -38,9 +38,9 @@ We have some new keywords as well. You'll see `require` which basically checks t
 
 In this case, it's checking if `prizeAmount <= address(this).balance`. Here, `address(this).balance` is the **balance of the contract itself.**
 
-Why? **Well, for us to send Ethereum to someone, our contract needs to have Ethereum on it.**
+Why? **Well, for us to send Ether to someone, our contract needs to have Ether on it.**
 
-How this works is when we first deploy the contract, we "fund" it :). So far, we've **never** funded our contract!! It's always been worth 0 ETH. That means our contract can't send people Ethereum because it **simply doesn't have any**! We'll cover funding in the next section!
+How this works is when we first deploy the contract, we "fund" it :). So far, we've **never** funded our contract!! It's always been worth 0 ETH. That means our contract can't send people Ether because it **simply doesn't have any**! We'll cover funding in the next section!
 
 What's cool about
 
@@ -56,10 +56,10 @@ is that it lets us make sure that the *balance of the contract* is bigger than t
 
 Pretty awesome, right :)?
 
-🏦 Fund the contract we can even send Ethereum!
+🏦 Fund the contract we can even send Ether!
 -----------------------------------------------
 
-We've now set up our code send Ethereum. Nice! Now we need to actually make sure our contract is funded, otherwise, we have no Ethereum to send!
+We've now set up our code send Ether. Nice! Now we need to actually make sure our contract is funded, otherwise, we have no Ether to send!
 
 We're going to first work in `run.js`. Remember, run.js is like our testing grounds where we want to make sure our contracts core functionality works before we go and deploy it. It's **really hard** to debug contract code and frontend code at the same time, so, we separate it out!
 
@@ -121,7 +121,7 @@ The magic is on `hre.ethers.utils.parseEther('0.001'),`. This where I say, "go a
 
 I then do `hre.ethers.utils.formatEther(contractBalance)` to test out to see if my contract actually has a balance of 0.1. I use a function that `ethers` gives me here called `getBalance` and pass it my contract's address!
 
-But then, we also want to see if when we call `wave` if 0.0001 Ethereum is properly removed from the contract!! That's why I print the balance out again after I call `wave`.
+But then, we also want to see if when we call `wave` if 0.0001 Ether is properly removed from the contract!! That's why I print the balance out again after I call `wave`.
 
 When we run 
 
@@ -159,7 +159,7 @@ This is what I get:
 
 **Boom**.
 
-We just sent some Ethereum from our contract, big success! And, we know we succeeded because the contract balance went down by 0.0001 Ethereum from 0.1 to 0.0999!
+We just sent some Ether from our contract, big success! And, we know we succeeded because the contract balance went down by 0.0001 Ether from 0.1 to 0.0999!
 
 ✈️ Update deploy script to fund contract
 ----------------------------------------
@@ -191,7 +191,7 @@ const runMain = async () => {
 runMain();
 ```
 
-All I did was fund the contract 0.001 Ethereum like this:
+All I did was fund the contract 0.001 Ether like this:
 
 ```javascript
 const waveContract = await waveContractFactory.deploy({

--- a/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
+++ b/Solidity_And_Smart_Contracts/Section_5/Lesson_1_Randomly_Pick_Winner.md
@@ -1,7 +1,7 @@
 😈 Randomly pick winner
 -----------------------
 
-So right now, our code is set to give the waver 0.0001 Ethereum every single time! Our contract will run out of money pretty fast, and then the fun is over and we'd need to add more funds to our contract. In this lesson, I'll walk you through how to:
+So right now, our code is set to give the waver 0.0001 Ether every single time! Our contract will run out of money pretty fast, and then the fun is over and we'd need to add more funds to our contract. In this lesson, I'll walk you through how to:
 
 1\. **Randomly** pick a winner.
 
@@ -173,7 +173,7 @@ Boom! It works. When "79" was generated, the user didn't win the prize. But, whe
 Cooldowns to prevent spammers
 -----------------------------
 
-Awesome. You have a way to randomly send Ethereum to people now! Now, it might be useful to add a cooldown function to your site so people can't just spam wave at you. Why? Well, maybe you just don't want them to keep on trying to win the prize over and over by waving at you. Or, maybe you don't want *just* *their* messages filling up your wall of messages.
+Awesome. You have a way to randomly send Ether to people now! Now, it might be useful to add a cooldown function to your site so people can't just spam wave at you. Why? Well, maybe you just don't want them to keep on trying to win the prize over and over by waving at you. Or, maybe you don't want *just* *their* messages filling up your wall of messages.
 
 Check out the code. I added comments where I added new lines.
 


### PR DESCRIPTION
Went through solidity lessons and changed any mention of 'ethereum' referring to currency; should be 'ether' or ETH.