### PR TITLE
Avoid inline component definitions

### DIFF
--- a/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
+++ b/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
@@ -43,9 +43,9 @@ const App = () => {
 
   return (
 		// blah blah all your html here
-    <button className="cta-button connect-wallet-button">
-      Connect to Wallet
-    </button>
+		<button className="cta-button connect-wallet-button">
+			Connect to Wallet
+		</button>
   );
 };
 
@@ -119,9 +119,9 @@ const App = () => {
 
   return (
 		 // blah blah all your html here
-    <button className="cta-button connect-wallet-button">
-      Connect to Wallet
-    </button>
+		<button className="cta-button connect-wallet-button">
+			Connect to Wallet
+		</button>
   );
 };
 

--- a/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
+++ b/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
@@ -18,12 +18,6 @@ const TWITTER_LINK = `https://twitter.com/${TWITTER_HANDLE}`;
 const OPENSEA_LINK = '';
 const TOTAL_MINT_COUNT = 50;
 
-const WalletNotConnected = () => (
-  <button className="cta-button connect-wallet-button">
-    Connect to Wallet
-  </button>
-);
-
 const App = () => {
 
     const checkIfWalletIsConnected = () => {
@@ -49,6 +43,9 @@ const App = () => {
 
   return (
 		// blah blah all your html here
+    <button className="cta-button connect-wallet-button">
+      Connect to Wallet
+    </button>
   );
 };
 
@@ -78,13 +75,6 @@ const TWITTER_HANDLE = '_buildspace';
 const TWITTER_LINK = `https://twitter.com/${TWITTER_HANDLE}`;
 const OPENSEA_LINK = '';
 const TOTAL_MINT_COUNT = 50;
-
-const WalletNotConnected = () => (
-  <button className="cta-button connect-wallet-button">
-    Connect to Wallet
-  </button>
-);
-
 
 const App = () => {
 
@@ -129,6 +119,9 @@ const App = () => {
 
   return (
 		 // blah blah all your html here
+    <button className="cta-button connect-wallet-button">
+      Connect to Wallet
+    </button>
   );
 };
 
@@ -153,24 +146,6 @@ const TWITTER_HANDLE = '_buildspace';
 const TWITTER_LINK = `https://twitter.com/${TWITTER_HANDLE}`;
 const OPENSEA_LINK = '';
 const TOTAL_MINT_COUNT = 50;
-
-/*
-* We added a simple onClick event on the button.
-*/
-const WalletNotConnected = ({ connectWallet }) => (
-  <button onClick={connectWallet} className="cta-button connect-wallet-button">
-    Connect to Wallet
-  </button>
-);
-
-/*
-* We want the "Connect to Wallet" button to dissapear if they've already connected their wallet!
-*/
-const Mint = () => (
-  <button onClick={null} className="cta-button connect-wallet-button">
-    Mint NFT
-  </button>
-)
 
 const App = () => {
 
@@ -239,7 +214,15 @@ const App = () => {
           <p className="sub-text">
             Each unique. Each beautiful. Discover your NFT today.
           </p>
-          {currentAccount === "" ? <WalletNotConnected connectWallet={connectWallet} /> : <Mint />}
+          {currentAccount === "" ? (
+            <button onClick={connectWallet} className="cta-button connect-wallet-button">
+              Connect to Wallet
+            </button>
+          ) : (
+            <button onClick={null} className="cta-button connect-wallet-button">
+              Mint NFT
+            </button>
+          )}
         </div>
         <div className="footer-container">
           <img alt="Twitter Logo" className="twitter-logo" src={twitterLogo} />

--- a/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
+++ b/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
@@ -42,10 +42,10 @@ const App = () => {
   }, [])
 
   return (
-		// blah blah all your html here
-		<button className="cta-button connect-wallet-button">
-			Connect to Wallet
-		</button>
+    // blah blah all your html here
+    <button className="cta-button connect-wallet-button">
+      Connect to Wallet
+    </button>
   );
 };
 
@@ -118,10 +118,10 @@ const App = () => {
   }, [])
 
   return (
-		 // blah blah all your html here
-		<button className="cta-button connect-wallet-button">
-			Connect to Wallet
-		</button>
+    // blah blah all your html here
+    <button className="cta-button connect-wallet-button">
+      Connect to Wallet
+    </button>
   );
 };
 

--- a/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
+++ b/NFT_Collection/Section_4/Lesson_2_Connect_Wallet_To_Web_App.md
@@ -18,6 +18,12 @@ const TWITTER_LINK = `https://twitter.com/${TWITTER_HANDLE}`;
 const OPENSEA_LINK = '';
 const TOTAL_MINT_COUNT = 50;
 
+const WalletNotConnected = () => (
+  <button className="cta-button connect-wallet-button">
+    Connect to Wallet
+  </button>
+);
+
 const App = () => {
 
     const checkIfWalletIsConnected = () => {
@@ -40,12 +46,6 @@ const App = () => {
   useEffect(() => {
     checkIfWalletIsConnected();
   }, [])
-
-  const renderNotConnectedContainer = () => (
-    <button className="cta-button connect-wallet-button">
-      Connect to Wallet
-    </button>
-  );
 
   return (
 		// blah blah all your html here
@@ -78,6 +78,13 @@ const TWITTER_HANDLE = '_buildspace';
 const TWITTER_LINK = `https://twitter.com/${TWITTER_HANDLE}`;
 const OPENSEA_LINK = '';
 const TOTAL_MINT_COUNT = 50;
+
+const WalletNotConnected = () => (
+  <button className="cta-button connect-wallet-button">
+    Connect to Wallet
+  </button>
+);
+
 
 const App = () => {
 
@@ -120,12 +127,6 @@ const App = () => {
     checkIfWalletIsConnected();
   }, [])
 
-  const renderNotConnectedContainer = () => (
-    <button className="cta-button connect-wallet-button">
-      Connect to Wallet
-    </button>
-  );
-
   return (
 		 // blah blah all your html here
   );
@@ -152,6 +153,24 @@ const TWITTER_HANDLE = '_buildspace';
 const TWITTER_LINK = `https://twitter.com/${TWITTER_HANDLE}`;
 const OPENSEA_LINK = '';
 const TOTAL_MINT_COUNT = 50;
+
+/*
+* We added a simple onClick event on the button.
+*/
+const WalletNotConnected = ({ connectWallet }) => (
+  <button onClick={connectWallet} className="cta-button connect-wallet-button">
+    Connect to Wallet
+  </button>
+);
+
+/*
+* We want the "Connect to Wallet" button to dissapear if they've already connected their wallet!
+*/
+const Mint = () => (
+  <button onClick={null} className="cta-button connect-wallet-button">
+    Mint NFT
+  </button>
+)
 
 const App = () => {
 
@@ -210,24 +229,6 @@ const App = () => {
   }, [])
 
   /*
-  * We added a simple onClick event here.
-  */
-  const renderNotConnectedContainer = () => (
-    <button onClick={connectWallet} className="cta-button connect-wallet-button">
-      Connect to Wallet
-    </button>
-  );
-
-  /*
-  * We want the "Connect to Wallet" button to dissapear if they've already connected their wallet!
-  */
-  const renderMintUI = () => (
-    <button onClick={null} className="cta-button connect-wallet-button">
-      Mint NFT
-    </button>
-  )
-
-  /*
   * Added a conditional render! We don't want to show Connect to Wallet if we're already conencted :).
   */
   return (
@@ -238,7 +239,7 @@ const App = () => {
           <p className="sub-text">
             Each unique. Each beautiful. Discover your NFT today.
           </p>
-          {currentAccount === "" ? renderNotConnectedContainer() : renderMintUI()}
+          {currentAccount === "" ? <WalletNotConnected connectWallet={connectWallet} /> : <Mint />}
         </div>
         <div className="footer-container">
           <img alt="Twitter Logo" className="twitter-logo" src={twitterLogo} />

--- a/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
+++ b/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
@@ -70,11 +70,16 @@ Finally, we'll want to call this function when someone clicks the "Mint NFT" but
 
 ```jsx
 return (
-  ...
-  <button onClick={askContractToMintNft} className="cta-button connect-wallet-button">
-    Mint NFT
-  </button>
-  ...
+  {currentAccount === "" ? (
+    <button onClick={connectWallet} className="cta-button connect-wallet-button">
+      Connect to Wallet
+    </button>
+  ) : (
+    {/** Add askContractToMintNft Action for the onClick event **/}
+    <button onClick={askContractToMintNft} className="cta-button connect-wallet-button">
+      Mint NFT
+    </button>
+  )}
 );
 ```
 

--- a/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
+++ b/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
@@ -69,10 +69,10 @@ The rest of the code should already make sense. It looks sorta like the code we 
 Finally, we'll want to call this function when someone clicks the "Mint NFT" button.
 
 ```jsx
-const renderMintUI = () => (
-    <button onClick={askContractToMintNft} className="cta-button connect-wallet-button">
-      Mint NFT
-    </button>
+const Mint = ({ askContractToMintNft }) => (
+  <button onClick={askContractToMintNft} className="cta-button connect-wallet-button">
+    Mint NFT
+  </button>
 )
 ```
 

--- a/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
+++ b/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
@@ -69,17 +69,13 @@ The rest of the code should already make sense. It looks sorta like the code we 
 Finally, we'll want to call this function when someone clicks the "Mint NFT" button.
 
 ```jsx
-const Mint = ({ askContractToMintNft }) => (
+return (
+  ...
   <button onClick={askContractToMintNft} className="cta-button connect-wallet-button">
     Mint NFT
   </button>
-)
-```
-
-When using this component in your `App` you'll need to pass in `askContractToMintNft` as a prop.
-
-```jsx
-<Mint askContractToMintNft={askContractToMintNft}>
+  ...
+);
 ```
 
 

--- a/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
+++ b/NFT_Collection/Section_4/Lesson_3_Create_Button_To_Call_Contract.md
@@ -76,6 +76,12 @@ const Mint = ({ askContractToMintNft }) => (
 )
 ```
 
+When using this component in your `App` you'll need to pass in `askContractToMintNft` as a prop.
+
+```jsx
+<Mint askContractToMintNft={askContractToMintNft}>
+```
+
 
 📂 ABI files
 ----------------


### PR DESCRIPTION
Generally the following is considered a bad practice as we are defining a functional component within the render-scope of the rendering component.

```
const App = () => {
  const renderGreeting = () => <p>hi</p>;
  return renderGreeting();
}

vs

const Greeting = () => <p>hi</p>;

const App = () => {
  return <Greeting />
}
```

This is a very subtile weirdness that has the same effect as using a different "key" prop on every render. The child diffing will look at the type of every vnode and see that the functional identity has changed which will mean that we'll tear the subtree down rather than doing an update on it. destroy + create instead of update on every render.

This issue becomes clearer when we consider the following: https://codesandbox.io/s/dawn-leaf-je143?file=/src/App.js notice the CounterInline always being torn down