### PR TITLE
Update from deprecated version of networkVersion

### DIFF
--- a/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
+++ b/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
@@ -74,16 +74,16 @@ For that, we make a RPC request to the blockchain to see the ID of the chain our
 
 We have already addressed requests to the blockchain. We used `ethereum.request` with the methods `eth_accounts` and `eth_requestAccounts`. Now we use `eth_chainID` to get the ID.
 
-```js
+```javascript
 let chainID = await ethereum.request({ method: 'eth_chainId' });
 console.log("Connected to chain " + chainID);
 if (chainID !== "0x4" /*String, hex code of the chain ID of the Rinkebey test network */ ) {
-	alert("This website connects to a contract on the Rinkeby test network\nYour wallet is currently not connected to that network, so it won't work");
+	alert("You are not connected to the Rinkeby Test Network!");
 }
 ```
 There, now the user will know if they're on the wrong network! 
-The request conforms to [EIP-695](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-695.md) so returns the hex value of the network as a string.
-You can find other the IDs of the other networks on [here](https://docs.metamask.io/guide/ethereum-provider.html#chain-ids). 
+The request conforms to [EIP-695](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-695.md) so it returns the hex value of the network as a string.
+You can find other the IDs of the other networks [here](https://docs.metamask.io/guide/ethereum-provider.html#chain-ids). 
 
 
 🙉 Mining animation

--- a/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
+++ b/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
@@ -77,8 +77,10 @@ We have already addressed requests to the blockchain. We used `ethereum.request`
 ```javascript
 let chainId = await ethereum.request({ method: 'eth_chainId' });
 console.log("Connected to chain " + chainId);
-const rinkebey_chainId = "0x4"; // String, hex code of the chainId of the Rinkebey test network
-if (chainId !== rinkebey_chainId  ) {
+
+// String, hex code of the chainId of the Rinkebey test network
+const rinkebyChainId = "0x4"; 
+if (chainId !== rinkebyChainId) {
 	alert("You are not connected to the Rinkeby Test Network!");
 }
 ```

--- a/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
+++ b/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
@@ -83,7 +83,7 @@ if (chainID !== "0x4" /*String, hex code of the chain ID of the Rinkebey test ne
 ```
 There, now the user will know if they're on the wrong network! 
 The request conforms to [EIP-695](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-695.md) so returns the hex value of the network as a string.
-You can find other the IDs of the other networks on [chainlist](https://chainlist.org/). 
+You can find other the IDs of the other networks on [here](https://docs.metamask.io/guide/ethereum-provider.html#chain-ids). 
 
 
 🙉 Mining animation

--- a/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
+++ b/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
@@ -68,7 +68,7 @@ Hint, you'll need something in solidity called `require`. And, you'll like also 
 --------------
 Your website is **only** going to work on Rinkeby (since that's where your contract lives).
 
-Be sure to add a nice message somewhere telling users about this. You can also make it dynamic if you want and [detect their network](https://ethereum.stackexchange.com/questions/85194/how-to-check-the-current-metamask-network) and then say something like, "Hey — I see you're connected to mainnet but this only works on Rinkeby!". You can make this as fancy as you want!
+Be sure to add a nice message somewhere telling users about this. You can also make it dynamic if you want and [detect their network](https://docs.metamask.io/guide/ethereum-provider.html#ethereum-networkversion-deprecated) and then say something like, "Hey — I see you're connected to mainnet but this only works on Rinkeby!". You can make this as fancy as you want!
 
 🙉 Mining animation
 --------------

--- a/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
+++ b/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
@@ -72,18 +72,18 @@ We're going to to add a nice message telling users about this!
 
 For that, we make a RPC request to the blockchain to see the ID of the chain our wallet connects to. (Why a chain and not a network? [Good question!](https://ethereum.stackexchange.com/questions/37533/what-is-a-chainid-in-ethereum-how-is-it-different-than-networkid-and-how-is-it))
 
-We have already addressed requests to the blockchain. We used `ethereum.request` with the methods `eth_accounts` and `eth_requestAccounts`. Now we use `eth_chainID` to get the ID.
+We have already addressed requests to the blockchain. We used `ethereum.request` with the methods `eth_accounts` and `eth_requestAccounts`. Now we use `eth_chainId` to get the ID.
 
 ```javascript
-let chainID = await ethereum.request({ method: 'eth_chainId' });
-console.log("Connected to chain " + chainID);
-if (chainID !== "0x4" /*String, hex code of the chain ID of the Rinkebey test network */ ) {
+let chainId = await ethereum.request({ method: 'eth_chainId' });
+console.log("Connected to chain " + chainId);
+if (chainId !== "0x4" /*String, hex code of the chain ID of the Rinkebey test network */ ) {
 	alert("You are not connected to the Rinkeby Test Network!");
 }
 ```
-There, now the user will know if they're on the wrong network! 
+There, now the user will know if they are on the wrong network! 
 The request conforms to [EIP-695](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-695.md) so it returns the hex value of the network as a string.
-You can find other the IDs of the other networks [here](https://docs.metamask.io/guide/ethereum-provider.html#chain-ids). 
+You can find the IDs of other networks [here](https://docs.metamask.io/guide/ethereum-provider.html#chain-ids). 
 
 
 🙉 Mining animation

--- a/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
+++ b/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
@@ -68,7 +68,23 @@ Hint, you'll need something in solidity called `require`. And, you'll like also 
 --------------
 Your website is **only** going to work on Rinkeby (since that's where your contract lives).
 
-Be sure to add a nice message somewhere telling users about this. You can also make it dynamic if you want and [detect their network](https://docs.metamask.io/guide/ethereum-provider.html#ethereum-networkversion-deprecated) and then say something like, "Hey — I see you're connected to mainnet but this only works on Rinkeby!". You can make this as fancy as you want!
+We're going to to add a nice message telling users about this! 
+
+For that, we make a RPC request to the blockchain to see the ID of the chain our wallet connects to. (Why a chain and not a network? [Good question!](https://ethereum.stackexchange.com/questions/37533/what-is-a-chainid-in-ethereum-how-is-it-different-than-networkid-and-how-is-it))
+
+We have already addressed requests to the blockchain. We used `ethereum.request` with the methods `eth_accounts` and `eth_requestAccounts`. Now we use `eth_chainID` to get the ID.
+
+```js
+let chainID = await ethereum.request({ method: 'eth_chainId' });
+console.log("Connected to chain " + chainID);
+if (chainID !== "0x4" /*String, hex code of the chain ID of the Rinkebey test network */ ) {
+	alert("This website connects to a contract on the Rinkeby test network\nYour wallet is currently not connected to that network, so it won't work");
+}
+```
+There, now the user will know if they're on the wrong network! 
+The request conforms to [EIP-695](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-695.md) so returns the hex value of the network as a string.
+You can find other the IDs of the other networks on [chainlist](https://chainlist.org/). 
+
 
 🙉 Mining animation
 --------------

--- a/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
+++ b/NFT_Collection/Section_5/Lesson_1_Finishing_Touches_Web_App.md
@@ -77,7 +77,8 @@ We have already addressed requests to the blockchain. We used `ethereum.request`
 ```javascript
 let chainId = await ethereum.request({ method: 'eth_chainId' });
 console.log("Connected to chain " + chainId);
-if (chainId !== "0x4" /*String, hex code of the chain ID of the Rinkebey test network */ ) {
+const rinkebey_chainId = "0x4"; // String, hex code of the chainId of the Rinkebey test network
+if (chainId !== rinkebey_chainId  ) {
 	alert("You are not connected to the Rinkeby Test Network!");
 }
 ```


### PR DESCRIPTION
https://docs.metamask.io/guide/ethereum-provider.html#ethereum-networkversion-deprecated indicates `ethereum.networkVerstion` is now deprecated.
I'm proposing we change it to the link I put, since I can't find another place it's explicit.