### PR TITLE
Changed --network localhost to --network rinkeby

### DIFF
--- a/NFT_Collection/Section_2/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
+++ b/NFT_Collection/Section_2/Lesson_4_Create_A_Contract_That_Mints_NFTs.md
@@ -310,7 +310,7 @@ Why do you need to use your private key? Because in order to perform a transacti
 
 Once you've got your config setup we're set to deploy with the deploy script we wrote earlier.
 
-Run this command from the root directory of `epic-nfts`. Notice all we do is change it from `localhost` to `rinkeby`.
+Run this command from the root directory of `epic-nfts`.
 
 ```bash
 npx hardhat run scripts/deploy.js --network rinkeby


### PR DESCRIPTION
Removed the line that talked about changing localhost to rinkeby because in this course so far, we have not deployed to localhost, we only ran run.js script unlike intro to web3 where we ran both run.js and deploy.js locally.
so people who didn't take the intro to web3 course won't get confused.