### PR TITLE
add deployed() method to deploy script

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_1/Lesson_5_Deploy_Locally.md
+++ b/Solidity_And_Smart_Contracts/en/Section_1/Lesson_5_Deploy_Locally.md
@@ -41,6 +41,7 @@ const main = async () => {
 
   const Token = await hre.ethers.getContractFactory('WavePortal');
   const portal = await Token.deploy();
+  await portal.deployed();
 
   console.log('WavePortal address: ', portal.address);
 };


### PR DESCRIPTION
Update to Section 1, Lesson 5. Added deployed() method to deploy script. 

This ethers method will return a promise with the deployed contract.

https://docs.ethers.io/v5/api/contract/contract/#Contract-deployed