### PR TITLE
Added in link for SPDX License

### DIFF
--- a/NFT_Collection/en/Section_1/Lesson_3_Mint_A_NFT_Locally.md
+++ b/NFT_Collection/en/Section_1/Lesson_3_Mint_A_NFT_Locally.md
@@ -38,7 +38,7 @@ Let's go line-by-line here.
 // SPDX-License-Identifier: UNLICENSED
 ```
 
-Just a fancy comment.  It's called an "SPDX license identifier", feel free to Google what it is :).
+Just a fancy comment.  It's called an "SPDX license identifier", You can read more about that [here](https://spdx.org/licenses/).
 
 ```solidity
 pragma solidity ^0.8.0;


### PR DESCRIPTION
I've added the link for the SPDX license where users can gain more info about the License, instead of having them google about it and go into a rabbit hole