### PR TITLE
fix: remove duplicate section

### DIFF
--- a/NFT_Game/en/Section_4/Lesson_1_Finishing_Touches_UI.md
+++ b/NFT_Game/en/Section_4/Lesson_1_Finishing_Touches_UI.md
@@ -29,18 +29,6 @@ const [isLoading, setIsLoading] = useState(false);
 Next, we are going to need to set the state when we are running async operations, such as as calling `checkIfUserHasNFT` from our contract. We are going to add these setters in both `useEffects` like so:
 
 ```javascript
-// State
-const [currentAccount, setCurrentAccount] = useState(null);
-const [characterNFT, setCharacterNFT] = useState(null);
-/*
-* New state property added here
-*/
-const [isLoading, setIsLoading] = useState(false);
-```
-
-Next, we are going to need to set the state when we are running async operations, such as as calling `checkIfUserHasNFT` from our contract. We are going to add these setters in both `useEffects` like so:
-
-```javascript
 // UseEffects
 useEffect(() => {
   /*


### PR DESCRIPTION
The code snippet and explanation that set up state in the loading indicator section, are in there twice. Probably a copy pasta error!