### PR TITLE
Consistent prize value in code and description

### DIFF
--- a/Solidity_And_Smart_Contracts/en/Section_3/Lesson_2_Fund_Contract_Set_Prize.md
+++ b/Solidity_And_Smart_Contracts/en/Section_3/Lesson_2_Fund_Contract_Set_Prize.md
@@ -191,7 +191,7 @@ const runMain = async () => {
 runMain();
 ```
 
-All I did was fund the contract 0.01 ETH like this:
+All I did was fund the contract 0.001 ETH like this:
 
 ```javascript
 const waveContract = await waveContractFactory.deploy({


### PR DESCRIPTION
Next line says: `Now when you go to [Etherscan](https://rinkeby.etherscan.io/) and paste in your contract address you'll see that your contract now has a value of 0.001 ETH! Success!`

But the suggested code was setting 0.01 ethers.