### PR TITLE
Update setup client instructions

### DIFF
--- a/Solana_Core/en/Core_1/Lesson_4_Build_An_Interaction_Script.md
+++ b/Solana_Core/en/Core_1/Lesson_4_Build_An_Interaction_Script.md
@@ -19,7 +19,7 @@ code .
 ```
 
 #### ⚙ Set up the client script
-The beauty of `create-solana-client` is that we can get started writing client code right away! Jump into `index.ts` and import our dependencies and add this `initializeKeypair` function:
+The beauty of `create-solana-client` is that we can get started writing client code right away! Jump into `index.ts` and import our dependencies:
 ```ts
 // We're adding these
 import * as Web3 from '@solana/web3.js';


### PR DESCRIPTION
Initially instructed to add `initializeKeypair` with exports, only exports are shown in the first code example. This is potentially misleading since we are instructed to add `initializeKeypair` and given the code sample only in the second example.