### PR TITLE
Spelling error in line 37 in solana core 1 lesson 2

### DIFF
--- a/Solana_Core/en/Core_1/Lesson_2_Reading_Data_From_The_Blockchain.md
+++ b/Solana_Core/en/Core_1/Lesson_2_Reading_Data_From_The_Blockchain.md
@@ -34,7 +34,7 @@ Lamports are the smallest unit of Solana. If you're familiar with Ethereum ecosy
 
 Each account has a public key - it acts like an address for the account. Ya know how your wallet has an address that you use for receiving those spicy NFTs? Same thing! Solana addresses are just base58 encoded strings.
 
-`executable` is a boolean field that tells us if the account contains executable data. Data is what's stored in the account, and rent we'll cover later! 
+`executable` is a boolean field that tells us if the account contains executable data. Data is what's stored in the account, and rest we'll cover later! 
 
 Let's stick with the simple stuff for now :)
 


### PR DESCRIPTION
In line 37, close to the end, It is currently "and rent we'll cover later!" but it must be "and rest we'll cover later!"